### PR TITLE
Update monitor.go to support env for test timer

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -26,6 +26,7 @@ var dockerPassword = flag.String("password", "", "Registry password for pulling 
 var registryHost = flag.String("registry-host", "", "Hostname of the registry being monitored")
 var repository = flag.String("repository", "", "Repository on the registry to pull and push")
 var baseLayer = flag.String("base-layer-id", "", "Docker V1 ID of the base layer in the repository")
+var testInterval = flag.String("run-test-every", "", "the time between test in minutes")
 
 var (
 	healthy bool
@@ -444,7 +445,7 @@ func runMonitor() {
 	healthy = true
 
 	mainLoop := func() {
-		duration := 2 * time.Minute
+		duration := *testInterval * time.Minute
 
 		for {
 			if !firstLoop {

--- a/monitor.go
+++ b/monitor.go
@@ -26,7 +26,7 @@ var dockerPassword = flag.String("password", "", "Registry password for pulling 
 var registryHost = flag.String("registry-host", "", "Hostname of the registry being monitored")
 var repository = flag.String("repository", "", "Repository on the registry to pull and push")
 var baseLayer = flag.String("base-layer-id", "", "Docker V1 ID of the base layer in the repository")
-var testInterval = flag.String("run-test-every", "", "the time between test in minutes")
+var testInterval = flag.String("run-test-every", "2m", "the time between test in minutes")
 
 var (
 	healthy bool
@@ -445,7 +445,10 @@ func runMonitor() {
 	healthy = true
 
 	mainLoop := func() {
-		duration := *testInterval * time.Minute
+		duration, err := time.ParseDuration(*testInterval)
+		if err != nil {
+			log.Fatalf("Failed to parse time interval: %v", err)
+		}
 
 		for {
 			if !firstLoop {


### PR DESCRIPTION
Adding a ENV so a user to pick in minutes right now how soon a test should kick off again.  This may need to be changed to seconds for more detailed trouble shooting.