### PR TITLE
Feature: Add support for provide base image

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -25,10 +25,13 @@ var dockerUsername = flag.String("username", "", "Registry username for pulling 
 var dockerPassword = flag.String("password", "", "Registry password for pulling and pushing")
 var registryHost = flag.String("registry-host", "", "Hostname of the registry being monitored")
 var repository = flag.String("repository", "", "Repository on the registry to pull and push")
-var baseLayer = flag.String("base-layer-id", "", "Docker V1 ID of the base layer in the repository")
+var baseImage = flag.String("base-image", "", "Repository to use as base image for push image; instead of base-layer-id")
+var publicBase = flag.Bool("public-base", false, "Is the base image public or private (default: false)")
+var baseLayer = flag.String("base-layer-id", "", "Docker V1 ID of the base layer in the repository; instead of base-image")
 var testInterval = flag.String("run-test-every", "2m", "the time between test in minutes")
 
 var (
+	base    string
 	healthy bool
 	status  bool
 )
@@ -275,6 +278,32 @@ func pullTestImage(dockerClient *docker.Client) bool {
 	return true
 }
 
+func pullBaseImage(dockerClient *docker.Client) bool {
+	pullOptions := docker.PullImageOptions{
+		Repository:   *baseImage,
+		Tag:          "latest",
+		OutputStream: &LoggingWriter{},
+	}
+
+	var pullAuth docker.AuthConfiguration
+	if *publicBase {
+		pullAuth = docker.AuthConfiguration{}
+	} else {
+		pullAuth = docker.AuthConfiguration{
+			Username: *dockerUsername,
+			Password: *dockerPassword,
+		}
+	}
+
+	if err := dockerClient.PullImage(pullOptions, pullAuth); err != nil {
+		log.Errorf("Pull Error: %s", err)
+		status = false
+		return false
+	}
+
+	return true
+}
+
 func deleteTopLayer(dockerClient *docker.Client) bool {
 	imageHistory, err := dockerClient.ImageHistory(*repository)
 	if err != nil {
@@ -303,7 +332,7 @@ func createTagLayer(dockerClient *docker.Client) bool {
 	timestamp := t.Format("2006-01-02 15:04:05 -0700")
 
 	config := &docker.Config{
-		Image: *baseLayer,
+		Image: base,
 		Cmd:   []string{"sh", "echo", "\"" + timestamp + "\" > foo"},
 	}
 
@@ -409,8 +438,10 @@ func main() {
 		log.Fatalln("Missing repository flag")
 	}
 
-	if *baseLayer == "" {
-		log.Fatalln("Missing base-layer-id flag")
+	if *baseImage == "" && *baseLayer == "" {
+		log.Fatalln("Missing base-image and base-layer-id flag; only one of required")
+	} else if *baseImage != "" && *baseLayer != "" {
+		log.Fatalln("Both base-image and base-layer-id flag; only one of required")
 	}
 
 	// Register the metrics.
@@ -501,6 +532,16 @@ func runMonitor() {
 
 			// Write the pull time metric.
 			promPullMetric.Observe(time.Since(pullStartTime).Seconds())
+
+			if *baseImage != "" {
+				log.Infof("Pulling specified base image")
+				if !pullBaseImage(dockerClient) {
+					return
+				}
+				base = *baseImage
+			} else {
+				base = *baseLayer
+			}
 
 			log.Infof("Deleting top layer")
 			if !deleteTopLayer(dockerClient) {


### PR DESCRIPTION
Adds two new options `base-image` and `public-image`.

`base-image` supplies the name of the base image to use when creating
an image to push. The image is pulled for you. This avoids having to
know the layer id of the primary image being pulled and updated as
part of the tests.

`public-image` is a simple flag to indicate if the base image specified
is public (true) or private (false) (default is false). If private the
credentials provided will be used when pulling the base image.

The change is completely backwards-compatiable with previous options.