### PR TITLE
Feature: Minimal image for runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.glide/
+vendor/
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+.glide/
+bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,6 @@
-FROM golang
+FROM alpine:3.5
 
-ENV PATH /usr/local/go/bin:$PATH
-ENV GOPATH /gopath
 ENV UNDER_DOCKER true
 
-WORKDIR /gopath/src/github.com/coreos/registry-monitor
-RUN mkdir -p /gopath/src/github.com/coreos/registry-monitor
-ADD monitor.go /gopath/src/github.com/coreos/registry-monitor/monitor.go
-
-RUN go get -v ./...
-RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w' monitor.go
-
-ENTRYPOINT ["./monitor"]
+COPY bin/monitor /usr/local/bin
+ENTRYPOINT ["monitor"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,10 @@
+FROM golang:1.8
+
+ENV GLIDE_VERSION v0.12.3
+
+RUN curl -Lo /tmp/glide.tgz https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz \
+    && tar -C /usr/bin -xzf /tmp/glide.tgz --strip=1 linux-amd64/glide \
+    && rm /tmp/glide.tgz
+
+ENV CGO_ENABLED 0
+ENV GOPATH /go:/registry-monitor

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+MAKEFLAGS += --warn-undefined-variables
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -euc
+.DEFAULT_GOAL := build
+
+PROJECT := registry-monitor
+IMPORT_PATH := github.com/coreos/${PROJECT}
+IMAGE_NAME := quay.io/coreos/${PROJECT}
+DEV_IMAGE := ${PROJECT}_dev
+
+DOCKERRUN := docker run --rm -i \
+	-e PROJECT="${PROJECT}" \
+	-v /${PROJECT}/vendor:/go/src \
+	-v /${PROJECT}:/${PROJECT}/src/${IMPORT_PATH} \
+	-w /${PROJECT}/src/${IMPORT_PATH} \
+	${DEV_IMAGE}
+
+# ----------------------------------------------
+# build
+
+# default top-level target
+.PHONY: build
+build: build/dev
+
+.PHONY: build/dev
+build/dev: vendor *.go
+	@rm -rf bin/
+	@mkdir -p bin
+	${DOCKERRUN} go build -a -tags netgo -ldflags '-w' -o bin/monitor monitor.go
+
+# builds the builder container
+.PHONY: build/image_build
+build/image_build:
+	@echo "Building dev container"
+	@docker build --quiet -t ${DEV_IMAGE} -f Dockerfile.dev .
+
+# top-level target for vendoring our packages: glide install requires
+# being in the package directory so we have to run this for each package
+.PHONY: vendor
+vendor: build/image_build
+	${DOCKERRUN} glide install --skip-test
+
+# fetch a dependency via go get, vendor it, and then save into the parent
+# package's glide.yml
+# usage: DEP=github.com/owner/package make add-dep
+.PHONY: add-dep
+add-dep: build/image_build
+ifeq ($(strip $(DEP)),)
+	$(error "No dependency provided. Expected: DEP=<go import path>")
+endif
+	${DOCKERRUN} glide get --skip-test ${DEP}
+
+.PHONY: dist
+dist: build
+	docker build -t ${IMAGE_NAME} .

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,101 @@
+hash: e2cee1a8bee271fdfc3e1da50cdaa63bb46550de84eb15459ac0e145ec10e631
+updated: 2017-03-20T23:19:31.121617817Z
+imports:
+- name: github.com/Azure/go-ansiterm
+  version: fa152c58bc15761d0200cb75fe958b89a9d4888e
+  subpackages:
+  - winterm
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
+- name: github.com/coreos/pkg
+  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
+  subpackages:
+  - flagutil
+- name: github.com/docker/docker
+  version: 0bc84fc06c4be2b48afd3e50f199316e2d4d94fb
+  subpackages:
+  - api/types
+  - api/types/blkiodev
+  - api/types/container
+  - api/types/filters
+  - api/types/mount
+  - api/types/network
+  - api/types/registry
+  - api/types/strslice
+  - api/types/swarm
+  - api/types/versions
+  - opts
+  - pkg/archive
+  - pkg/fileutils
+  - pkg/homedir
+  - pkg/idtools
+  - pkg/ioutils
+  - pkg/jsonlog
+  - pkg/jsonmessage
+  - pkg/longpath
+  - pkg/pools
+  - pkg/promise
+  - pkg/stdcopy
+  - pkg/system
+  - pkg/term
+  - pkg/term/windows
+- name: github.com/docker/go-connections
+  version: a2afab9802043837035592f1c24827fb70766de9
+  subpackages:
+  - nat
+- name: github.com/docker/go-units
+  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+- name: github.com/fsouza/go-dockerclient
+  version: 87c7e50e0bcf800ed863c3c3b0fbcc67e3029140
+- name: github.com/golang/protobuf
+  version: c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
+  subpackages:
+  - proto
+- name: github.com/hashicorp/go-cleanhttp
+  version: 3573b8b52aa7b37b9358d966a898feb387f62437
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
+- name: github.com/Microsoft/go-winio
+  version: fff283ad5116362ca252298cfc9b95828956d85d
+- name: github.com/Nvveen/Gotty
+  version: cd527374f1e5bff4938207604a14f2e38a9cf512
+- name: github.com/opencontainers/runc
+  version: 767783a6310f43ee88bc04771f430b4f330a4a10
+  subpackages:
+  - libcontainer/system
+  - libcontainer/user
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  subpackages:
+  - xfs
+- name: github.com/Sirupsen/logrus
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+- name: golang.org/x/net
+  version: a6577fac2d73be281a500b310739095313165611
+  subpackages:
+  - context
+  - context/ctxhttp
+- name: golang.org/x/sys
+  version: 99f16d856c9836c42d24e7ab64ea72916925fa97
+  subpackages:
+  - unix
+  - windows
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,13 @@
+package: github.com/coreos/registry-monitor
+import:
+- package: github.com/Sirupsen/logrus
+  version: ^0.11.5
+- package: github.com/coreos/pkg
+  version: ^3.0.0
+  subpackages:
+  - flagutil
+- package: github.com/prometheus/client_golang
+  version: ^0.8.0
+  subpackages:
+  - prometheus
+- package: github.com/fsouza/go-dockerclient


### PR DESCRIPTION
Leverage a dev image for building the monitor binary and then copy
the binary into an alpine image for use at runtime.

Uses glide to manage dependencies so that each build will be repeatable.
Also includes a Makefile to assist with adding dependencies, creating
the local vendor directory, building the binary, and building the image.